### PR TITLE
No longer sends crash reports to fCraft.net.

### DIFF
--- a/fCraft/System/Logger.cs
+++ b/fCraft/System/Logger.cs
@@ -183,7 +183,7 @@ namespace fCraft {
 
             Log( LogType.SeriousError, "{0}: {1}", message, exception );
 
-            bool submitCrashReport = ConfigKey.SubmitCrashReports.Enabled();
+            bool submitCrashReport = false;//ConfigKey.SubmitCrashReports.Enabled();
             bool isCommon = CheckForCommonErrors( exception );
 
             try {


### PR DESCRIPTION
So that fragmer doesn't receive crash reports for servers running ProCraft.
