### PR TITLE
Add map converter for .mcf file

### DIFF
--- a/fCraft/MapConversion/MapFormat.cs
+++ b/fCraft/MapConversion/MapFormat.cs
@@ -33,6 +33,9 @@ namespace fCraft.MapConversion {
         /// <summary> Map foramt used by D3 server. </summary>
         D3,
 
+        /// <summary> Map format used by MCForge-Redux </summary>
+        MCF,
+
         /// <summary> Format used by Opticraft v0.2+. Support contributed by Jared Klopper (LgZ-optical). </summary>
         Opticraft,
 

--- a/fCraft/MapConversion/MapMCSharp.cs
+++ b/fCraft/MapConversion/MapMCSharp.cs
@@ -154,7 +154,7 @@ namespace fCraft.MapConversion {
         }
 
 
-        static readonly byte[] Mapping = new byte[256];
+        protected static readonly byte[] Mapping = new byte[256];
 
         static MapMCSharp() {
             Mapping[100] = (byte)Block.Glass;       // op_glass

--- a/fCraft/MapConversion/MapUtility.cs
+++ b/fCraft/MapConversion/MapUtility.cs
@@ -37,6 +37,7 @@ namespace fCraft.MapConversion {
             RegisterConverter( new MapIndev() );
             RegisterConverter( new MapOpticraft() );
             RegisterConverter( new MapRaw() );
+            RegisterConverter( new MapMCF() );
         }
 
 

--- a/fCraft/fCraft.csproj
+++ b/fCraft/fCraft.csproj
@@ -154,6 +154,7 @@
     <Compile Include="Drawing\DrawOps\WallsDrawOperation.cs" />
     <Compile Include="Drawing\IBrushFactory.cs" />
     <Compile Include="MapConversion\MapFCMv3.cs" />
+    <Compile Include="MapConversion\MapMCF.cs" />
     <Compile Include="Network\CpeConstants.cs" />
     <Compile Include="Network\DBConnect.cs" />
     <Compile Include="Player\Report.cs" />


### PR DESCRIPTION
This pull request adds a map converter for .mcf files

.mcf files are formatted exactly like .lvl files, however they store blocks as shorts rather than bytes (I don't know why..)

As such, this converter bases itself off of the MCSharp converter, but overrides the Load and Save methods.